### PR TITLE
Add stage deployment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,22 @@ on:
     branches:
       - '**'
   workflow_dispatch:
+  workflow_call:
+    outputs:
+      image_tag:
+        description: Docker image tag
+        value: ${{ jobs.build-and-publish.outputs.image_tag }}
+    secrets:
+      NEXUS_DEPLOYER:
+        required: true
+      NEXUS_DEPLOYER_PASS:
+        required: true
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.set_output.outputs.image_tag }}
     env:
       DOCKER_CONFIG: $HOME/.docker
 
@@ -22,13 +34,20 @@ jobs:
         echo '${{ secrets.NEXUS_DEPLOYER_PASS }}' | docker login nexus.kontur.io:8084 -u '${{ secrets.NEXUS_DEPLOYER }}' --password-stdin
         echo '${{ secrets.NEXUS_DEPLOYER_PASS }}' | docker login nexus.kontur.io:8085 -u '${{ secrets.NEXUS_DEPLOYER }}' --password-stdin
 
+    - name: Sanitize ref name for Docker tags
+      id: sanitize
+      run: |
+        REF_NAME='${{ github.ref_name }}'
+        SANITIZED=$(echo "$REF_NAME" | tr '/\,' '--')
+        echo "ref_name=$SANITIZED" >> "$GITHUB_OUTPUT"
+
     - name: Extract Chromium Docker metadata
       uses: docker/metadata-action@v4.1.1
       id: meta-chromium
       with:
         images: nexus.kontur.io:8085/konturdev/chromium-headless
         tags: |
-          type=raw,value=${{ github.ref_name }}.{{sha}}.${{ github.run_attempt }}
+          type=raw,value=${{ steps.sanitize.outputs.ref_name }}.{{sha}}.${{ github.run_attempt }}
 
     - name: Build and push Chromium image
       uses: docker/build-push-action@v3.2.0
@@ -45,7 +64,7 @@ jobs:
       with:
         images: nexus.kontur.io:8085/konturdev/preview-generator
         tags: |
-          type=raw,value=${{ github.ref_name }}.{{sha}}.${{ github.run_attempt }}
+          type=raw,value=${{ steps.sanitize.outputs.ref_name }}.{{sha}}.${{ github.run_attempt }}
 
     - name: Build and push Preview Generator image
       uses: docker/build-push-action@v3.2.0
@@ -58,3 +77,7 @@ jobs:
     - name: Write image tags summary
       run: |-
         echo "<h3>Docker image tag</h3> ${{ steps.meta-preview.outputs.version }} <br><br>" >> $GITHUB_STEP_SUMMARY
+
+    - name: Set output for image tag
+      id: set_output
+      run: echo "image_tag=${{ steps.meta-preview.outputs.tags }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -1,0 +1,215 @@
+name: Deploy to Stage
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - test
+
+jobs:
+  notify-start:
+    runs-on: ubuntu-24.04
+    outputs:
+      slack_ts: ${{ steps.slack-info.outputs.slack_ts }}
+    steps:
+      - name: Send initial Slack notification
+        id: slack-init
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.postMessage
+          errors: true
+          payload: |
+            {
+              "text": "*🔄 EPIG Deployment to ${{ github.event.inputs.environment == 'dev' && 'DEV' || 'TEST' }}*\n              *Status:* Building image *Created by:* <https://github.com/${{ github.actor }}|${{ github.actor }}>\n              *Branch:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>\n",
+              "channel": "${{ secrets.SLACK_DEPLOY_STAGE_CHANNEL }}",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }
+
+      - name: Extract Slack message info
+        id: slack-info
+        run: |
+          RESPONSE='${{ steps.slack-init.outputs.response }}'
+          OK=$(echo "$RESPONSE" | jq -r '.ok')
+          if [ "$OK" != "true" ]; then
+            echo "Error: Slack API call failed with response: $RESPONSE"
+            exit 1
+          fi
+          SLACK_TS=$(echo "$RESPONSE" | jq -r '.ts')
+          if [ -z "$SLACK_TS" ]; then
+            echo "Error: Missing Slack timestamp"
+            exit 1
+          fi
+          echo "slack_ts=${SLACK_TS}" >> $GITHUB_OUTPUT
+
+  build-and-publish:
+    needs: notify-start
+    uses: ./.github/workflows/build.yml
+    secrets:
+      NEXUS_DEPLOYER: ${{ secrets.NEXUS_DEPLOYER }}
+      NEXUS_DEPLOYER_PASS: ${{ secrets.NEXUS_DEPLOYER_PASS }}
+
+  update-helm-manifests:
+    needs: [notify-start, build-and-publish]
+    runs-on: ubuntu-24.04
+    outputs:
+      image_tag: ${{ steps.set_image_tag.outputs.image_tag }}
+    steps:
+      - name: Set IMAGE_TAG output
+        id: set_image_tag
+        run: |
+          DOCKER_TAGS="${{ needs.build-and-publish.outputs.image_tag }}"
+          IMAGE_TAG="${DOCKER_TAGS##*:}"
+          echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Update Slack notification with image tag
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.update
+          errors: true
+          payload: |
+            {
+              "text": "*🔄 EPIG Deployment to ${{ github.event.inputs.environment == 'dev' && 'DEV' || 'TEST' }}*\n              *Status:* Updating manifests *Created by:* <https://github.com/${{ github.actor }}|${{ github.actor }}>\n              *Branch:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>\n              *Image Tag:* `${{ steps.set_image_tag.outputs.image_tag }}`",
+              "channel": "${{ secrets.SLACK_DEPLOY_STAGE_CHANNEL }}",
+              "ts": "${{ needs.notify-start.outputs.slack_ts }}",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }
+
+      - name: Checkout CD repository
+        uses: actions/checkout@v4
+        with:
+          repository: konturio/disaster-ninja-cd
+          token: ${{ secrets.CD_GITHUB_TOKEN }}
+          fetch-depth: 0
+          path: cd
+
+      - name: Install yq utility
+        run: |
+          wget -qO /tmp/yq https://github.com/mikefarah/yq/releases/download/v4.34.2/yq_linux_amd64
+          chmod +x /tmp/yq
+          sudo mv /tmp/yq /usr/local/bin/yq
+
+      - name: Update image tag in values file
+        working-directory: cd/helm/epig/values
+        run: |
+          echo "Updating image tag to ${{ steps.set_image_tag.outputs.image_tag }}"
+          yq -i ".containers.chromium_headless.tag = \"${{ steps.set_image_tag.outputs.image_tag }}\"" values-${{ github.event.inputs.environment }}.yaml
+          yq -i ".containers.preview_generator.tag = \"${{ steps.set_image_tag.outputs.image_tag }}\"" values-${{ github.event.inputs.environment }}.yaml
+          echo "New contents of values-${{ github.event.inputs.environment }}.yaml:"
+          cat values-${{ github.event.inputs.environment }}.yaml
+
+      - name: Bump version in Chart.yaml
+        working-directory: cd/helm/epig
+        run: |
+          echo "Current contents of Chart.yaml:"
+          cat Chart.yaml
+          CURRENT_VERSION=$(grep '^version:' Chart.yaml | awk '{print $2}')
+          IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
+          NEW_PATCH=$((patch + 1))
+          NEW_VERSION="${major}.${minor}.${NEW_PATCH}"
+          echo "Updating Chart version from $CURRENT_VERSION to $NEW_VERSION"
+          yq -i ".version = \"${NEW_VERSION}\"" Chart.yaml
+          echo "New contents of Chart.yaml:"
+          cat Chart.yaml
+
+      - name: Create and push changes branch
+        working-directory: cd
+        run: |
+          BRANCH_NAME="deploy-epig-${{ github.event.inputs.environment }}-${{ github.run_id }}"
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git checkout -b $BRANCH_NAME
+          git add .
+          git commit -m "Deploy EPIG to ${{ github.event.inputs.environment }}: update image tag to ${{ steps.set_image_tag.outputs.image_tag }} and bump Chart version"
+          git push origin $BRANCH_NAME
+        env:
+          GITHUB_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}
+
+      - name: Create Pull Request using gh
+        working-directory: cd
+        run: |
+          BRANCH_NAME="deploy-epig-${{ github.event.inputs.environment }}-${{ github.run_id }}"
+          gh pr create \
+            --title "Deploy EPIG to ${{ github.event.inputs.environment }}: update image tag to ${{ steps.set_image_tag.outputs.image_tag }} and bump Chart version. RunId: ${{ github.run_id }}" \
+            --body "Automatically created PR to update helm manifests with the new image tag. @coderabbitai ignore" \
+            --base main --head $BRANCH_NAME
+        env:
+          GITHUB_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}
+
+      - name: Merge Pull Request using gh
+        working-directory: cd
+        run: |
+          PR_NUMBER=$(gh pr list --head "deploy-epig-${{ github.event.inputs.environment }}-${{ github.run_id }}" --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR found for branch deploy-epig-${{ github.event.inputs.environment }}-${{ github.run_id }}. Exiting."
+            exit 1
+          fi
+          echo "Merging PR #$PR_NUMBER"
+          gh pr merge $PR_NUMBER --squash --delete-branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}
+
+  notify-result:
+    needs: [notify-start, build-and-publish, update-helm-manifests]
+    runs-on: ubuntu-24.04
+    if: ${{ always() && !cancelled() }}
+    steps:
+      - name: Update Slack notification on Success
+        if: needs.update-helm-manifests.result == 'success' && needs.build-and-publish.result == 'success'
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.update
+          errors: true
+          payload: |
+            {
+              "text": "*🏁 EPIG Deployment to ${{ github.event.inputs.environment == 'dev' && 'DEV' || 'TEST' }}*\n              *Status:* Done *Created by:* <https://github.com/${{ github.actor }}|${{ github.actor }}>\n              *Branch:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>\n              *Image Tag:* `${{ needs.update-helm-manifests.outputs.image_tag }}`",
+              "channel": "${{ secrets.SLACK_DEPLOY_STAGE_CHANNEL }}",
+              "ts": "${{ needs.notify-start.outputs.slack_ts }}",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }
+      - name: Update Slack notification on Failure
+        if: needs.notify-start.result == 'success' && (needs.update-helm-manifests.result != 'success' || needs.build-and-publish.result != 'success')
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.update
+          errors: true
+          payload: |
+            {
+              "text": "*❌ EPIG Deployment to ${{ github.event.inputs.environment == 'dev' && 'DEV' || 'TEST' }}*\n              *Status:* Failed *Created by:* <https://github.com/${{ github.actor }}|${{ github.actor }}>\n              *Branch:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>",
+              "channel": "${{ secrets.SLACK_DEPLOY_STAGE_CHANNEL }}",
+              "ts": "${{ needs.notify-start.outputs.slack_ts }}",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }
+
+  notify-cancel:
+    needs: [notify-start, build-and-publish, update-helm-manifests]
+    runs-on: ubuntu-24.04
+    if: ${{ cancelled() }}
+    steps:
+      - name: Update Slack notification on Cancelled
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.update
+          errors: true
+          payload: |
+            {
+              "text": "*❌ EPIG Deployment to ${{ github.event.inputs.environment == 'dev' && 'DEV' || 'TEST' }}*\n              *Status:* Cancelled *Created by:* <https://github.com/${{ github.actor }}|${{ github.actor }}>\n              *Branch:* <https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}|${{ github.ref_name }}>",
+              "channel": "${{ secrets.SLACK_DEPLOY_STAGE_CHANNEL }}",
+              "ts": "${{ needs.notify-start.outputs.slack_ts }}",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }


### PR DESCRIPTION
## Summary
- add reusable workflow output in `build.yml`
- add stage deploy workflow that updates EPIG Helm chart
- sanitize branch names in docker tags
- ensure full git history when modifying CD repository

## Testing
- `yamllint .github/workflows/build.yml .github/workflows/deploy_stage.yml | head`


------
https://chatgpt.com/codex/tasks/task_e_685e73208f7c8324b3c400b44bb76094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Deploy to Stage" workflow for streamlined deployments to development and test environments, including automated Slack notifications and Helm manifest updates.
  * Enabled the build workflow to be triggered by other workflows, with improved image tagging and outputs for downstream processes.

* **Chores**
  * Enhanced workflow automation for Docker image building, publishing, and deployment notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->