### PR TITLE
Improve caching

### DIFF
--- a/preview-generator/README.md
+++ b/preview-generator/README.md
@@ -71,6 +71,10 @@ CACHE_TTL=60
 CACHE_PASSWORD='redis_password'
 ```
 
+The service adds `Cache-Control` headers based on `CACHE_TTL` when caching is enabled.
+To invalidate a cached preview send a `DELETE` request to the same URL with the
+desired query parameters.
+
 ## Usage
 
 ### Local run

--- a/preview-generator/TODO.md
+++ b/preview-generator/TODO.md
@@ -3,3 +3,4 @@
 * Fix or replace aiocache
   aiocache uses the old aioredis, which is now part of the redis-py package.
   aiocache has a problem with memcached
+  (Improved caching logic and added invalidation and locking)


### PR DESCRIPTION
## Summary
- implement manual cache lock to avoid duplicate screenshot jobs
- add cache invalidation via DELETE endpoint
- set `Cache-Control` headers based on `CACHE_TTL`
- update docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ee3397e8c8324b935fa2f18d1445d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to manually invalidate cached previews by sending a DELETE request to the preview endpoint.
  * HTTP responses for previews now include appropriate Cache-Control headers based on cache settings.

* **Bug Fixes**
  * Improved caching logic to prevent multiple concurrent cache misses and ensure more reliable cache behavior.

* **Documentation**
  * Updated documentation to clarify cache behavior, header usage, and cache invalidation process.
  * Added notes about improved caching logic and mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->