### PR TITLE
Fix chromium crashpad issue in k8s

### DIFF
--- a/chromium-headless/entrypoint.sh
+++ b/chromium-headless/entrypoint.sh
@@ -20,6 +20,10 @@ COMMON_SWITCHES="--headless \
   --disable-software-rasterizer \
   --disable-renderer-backgrounding \
   --disable-background-timer-throttling \
+  --disable-crashpad \
+  --disable-crash-reporter \
+  --disable-breakpad \
+  --crash-dumps-dir=/tmp \
   --hide-scrollbars \
   --run-all-compositor-stages-before-draw \
   --window-size=${CHROMIUM_WIDTH:-1200},${CHROMIUM_HEIGHT:-630} \


### PR DESCRIPTION
## Summary
- disable crashpad and related crash reporters in entrypoint script
- revert README changes

## Testing
- `python -m py_compile preview-generator/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685f1ab17fa48324a40248328d5ea73c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Chromium launch settings to further disable crash reporting and specify a directory for crash dumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->