### PR TITLE
Reduce path tunables in Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 The project is designed to create screenshots of a web page on a browser event. Can be used to create
 preview for later use when posting on social media using the opengraph protocol.
 
-The project uses 2 containers: chromium-headless and preview-generator. You can optionally use redis or
-memcached for image caching
+The project uses two containers: **chromium-headless** and **preview-generator**. You can optionally use redis or
+memcached for image caching. When running them directly with Docker you may want to mount two directories for persistent data:
+
+* `/app/cache` - Chromium profile and cache
+* `/app/share` - output screenshots and PDFs
 
 ## [Chromium headless](chromium-headless/README.md)
 

--- a/chromium-headless/Dockerfile
+++ b/chromium-headless/Dockerfile
@@ -1,9 +1,6 @@
 ARG ALPINE_VERSION=3.22
 FROM alpine:${ALPINE_VERSION}
 
-ENV WORKDIR=/app \
-    CHROME_PATH=/usr/bin/chromium-browser
-
 RUN set -xe && \
     apk upgrade --no-cache --available && \
     apk add --no-cache \
@@ -16,18 +13,18 @@ RUN set -xe && \
         chromium-swiftshader \
         chromium \
         socat \
-        && \
-        mkdir -p ${WORKDIR}/cache/chromium && \
-        mkdir -p ${WORKDIR}/cache/fonts && \
-        mkdir -p ${WORKDIR}/share
+    && \
+    mkdir -p /app/cache/chromium && \
+    mkdir -p /app/cache/fonts && \
+    mkdir -p /app/share
 
 COPY fonts.conf /etc/fonts/local.conf
-COPY entrypoint.sh ${WORKDIR}
+COPY entrypoint.sh /app/
 
-RUN chmod +x ${WORKDIR}/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
-WORKDIR ${WORKDIR}/share
+WORKDIR /app/share
 
 EXPOSE ${CHROMIUM_PORT}
 
-ENTRYPOINT ["../entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/chromium-headless/README.md
+++ b/chromium-headless/README.md
@@ -25,6 +25,13 @@ path `/app/cache` and you need to define a variable
 
 * CHROMIUM_CACHE_SIZE - cache size (in bytes)
 
+### Volumes
+
+Bind mount the following directories if you need to persist files outside of the container:
+
+* `/app/cache` - Chromium user data and cache
+* `/app/share` - output directory for generated screenshots or pdfs
+
 To adjust the window size, set the following optional variables:
 
 * `CHROMIUM_WIDTH` - window width in pixels (default `1200`)

--- a/chromium-headless/entrypoint.sh
+++ b/chromium-headless/entrypoint.sh
@@ -28,9 +28,9 @@ COMMON_SWITCHES="--headless \
   --run-all-compositor-stages-before-draw \
   --window-size=${CHROMIUM_WIDTH:-1200},${CHROMIUM_HEIGHT:-630} \
   --remote-debugging-port=2222 \
-  --user-data-dir=${WORKDIR}/cache/chromium \
+  --user-data-dir=/app/cache/chromium \
   --disk-cache-size=${CHROMIUM_CACHE_SIZE}"
 
 socat TCP-LISTEN:${CHROMIUM_PORT:-9222},reuseaddr,fork TCP:127.0.0.1:2222 &
 
-"${CHROME_PATH}" ${COMMON_SWITCHES} "$@"
+/usr/bin/chromium-browser ${COMMON_SWITCHES} "$@"


### PR DESCRIPTION
## Summary
- hard code paths in `chromium-headless` Dockerfile and entrypoint
- document bind mounts
- note mount paths in main README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f1ca36b4c832481a0578a66064b11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README files to clarify container usage and emphasize recommended volume mounts for persistent data storage.
  * Added explicit instructions for mounting directories when running containers with Docker.

* **Refactor**
  * Simplified Dockerfile and entrypoint script by replacing environment variable-based paths with explicit absolute paths for directories and executables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->