### PR TITLE
fix(chromium-headless): update egl flags

### DIFF
--- a/chromium-headless/README.md
+++ b/chromium-headless/README.md
@@ -29,7 +29,8 @@ path `/app/cache` and you need to define a variable
 * CHROMIUM_GPU_MODE - GPU backend selection. Allowed values:
   * `software` - default; uses SwiftShader for CPU rendering.
   * `gl` - hardware acceleration via desktop GLX.
-  * `egl` - hardware acceleration via ANGLE and EGL.
+  * `egl` - hardware acceleration via ANGLE and EGL using a surfaceless Ozone platform.
+    Chrome is started with `--use-gl=angle --use-angle=gl-egl --ozone-platform=surfaceless --use-cmd-decoder=passthrough` in this mode.
   * `vulkan` - hardware acceleration via ANGLE Vulkan.
 
 ### Volumes

--- a/chromium-headless/entrypoint.sh
+++ b/chromium-headless/entrypoint.sh
@@ -19,8 +19,9 @@ case "$GPU_MODE" in
     ;;
   egl)
     DISABLE_FEATURES="${DISABLE_FEATURES},Vulkan"
-    GPU_SWITCHES="--use-angle=gl-egl \
-      --use-gl=egl \
+    GPU_SWITCHES="--use-gl=angle \
+      --use-angle=gl-egl \
+      --ozone-platform=surfaceless \
       --use-cmd-decoder=passthrough"
     ;;
   gl)


### PR DESCRIPTION
## Summary
- update EGL mode flags in entrypoint script
- document EGL mode behaviour in README

## Testing
- `make precommit` *(fails: No rule to make target 'precommit')*
- `find . -name '*.py' -print0 | xargs -0 python3 -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_686968248b98832485a8e2253163d971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the explanation of the `egl` GPU backend mode, detailing the specific Chrome startup flags used.

* **Bug Fixes**
  * Updated the GPU mode configuration for the `egl` option to improve compatibility by adjusting and adding Chrome startup flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->